### PR TITLE
feat: Prometheus の Target で docker の DNS を利用して名前解決する

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -24,8 +24,8 @@ services:
     volumes:
       - ./config/opentelemetry-collector/config.yaml:/etc/config.yaml
     ports:
-      - "9464" # Prometheus exporter
-      - "8888" # OpenTelemetry metrics
+      - "9464:9464" # Prometheus exporter
+      - "8888:8888" # OpenTelemetry metrics
   prometheus:
     image: prom/prometheus:v2.44.0
     container_name: prometheus

--- a/config/prometheus/config.yaml
+++ b/config/prometheus/config.yaml
@@ -7,7 +7,9 @@ scrape_configs:
   static_configs:
   - targets:
     - 'opentelemetry-collector:9464'
+    # - 'host.docker.internal:9464'
 - job_name: otel-collector
   static_configs:
   - targets:
     - 'opentelemetry-collector:8888'
+    # - 'host.docker.internal:8888'


### PR DESCRIPTION
# Overview

Prometheus には target を表示でき、その target で参照可能なメトリクスの一覧を表示できる
`host.docker.internal` を利用して名前解決するように Prometheus の設定ファイルを変更した

![image](https://github.com/pyama2000/demo-opentelemetry/assets/33086493/82fc0dec-f6dc-480e-8abc-8c631f428657)
